### PR TITLE
Migrate Virtual Y small banner image

### DIFF
--- a/openy_gated_content.post_update.php
+++ b/openy_gated_content.post_update.php
@@ -151,7 +151,9 @@ function openy_gated_content_post_update_paragraph_headline(&$sandbox) {
       if (!empty($header_prgf->field_prgf_headline->value)) {
         $title = $header_prgf->field_prgf_headline->value;
       }
-
+      if (!empty($header_prgf->field_prgf_image->first())) {
+        $image = $header_prgf->field_prgf_image->first();
+      }
       if (!empty($header_prgf->field_prgf_description->value)) {
         $description = $header_prgf->field_prgf_description->value;
       }
@@ -164,6 +166,9 @@ function openy_gated_content_post_update_paragraph_headline(&$sandbox) {
     if (empty($gated_content_prgf->field_prgf_description->value)) {
       $gated_content_prgf->field_prgf_description->value = $description;
       $gated_content_prgf->field_prgf_description->format = 'full_html';
+    }
+    if (empty($gated_content_prgf->field_prgf_image->first())) {
+      $gated_content_prgf->field_prgf_image->set(0, $image);
     }
     $gated_content_prgf->save();
   }


### PR DESCRIPTION
**Related Issue/Ticket:**

https://github.com/ymcatwincities/openy_gated_content/issues/107
https://openy.atlassian.net/browse/PRODDEV-225

## Steps to test:

- [ ] Import a db from 1.1
- [ ] Add an image to the Small Banner paragraph on  `/virtual-ymca`
- [ ] `drush updb`
- [ ] Observe the image is migrated.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
